### PR TITLE
Fix ssh encrypted private keys (ed25519 et al) and proxycommand none in ssh/config

### DIFF
--- a/ssh/connect_proxy_ssh.go
+++ b/ssh/connect_proxy_ssh.go
@@ -17,7 +17,7 @@ func createClientViaProxy(config conf.ServerConfig, sshConf *ssh.ClientConfig, p
 	switch {
 	// direct connect ssh proxy
 	case (proxyClient == nil) && (dialer == nil):
-		if config.ProxyCommand == "" { // not set ProxyCommand
+		if config.ProxyCommand == "" || config.ProxyCommand == "none" { // not set ProxyCommand
 			client, err = ssh.Dial("tcp", net.JoinHostPort(config.Addr, config.Port), sshConf)
 		} else { // set ProxyCommand
 			client, err = createClientViaProxyCommand(config, sshConf)

--- a/ssh/connect_ssh_agent.go
+++ b/ssh/connect_ssh_agent.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"fmt"
+	sshkeys "github.com/ScaleFT/sshkeys"
 	"io/ioutil"
 	"net"
 	"os"
@@ -95,7 +96,7 @@ func parseKeyArray(keyPathStr string) (key interface{}, err error) {
 
 	// parse key data
 	if len(keyArray) > 1 {
-		key, err = ssh.ParseRawPrivateKeyWithPassphrase(keyData, []byte(keyArray[1]))
+		key, err = sshkeys.ParseEncryptedPrivateKey(keyData, []byte(keyArray[1]))
 	} else {
 		key, err = ssh.ParseRawPrivateKey(keyData)
 	}

--- a/ssh/run_auth.go
+++ b/ssh/run_auth.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"fmt"
+	sshkeys "github.com/ScaleFT/sshkeys"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -123,7 +124,7 @@ func createSshSignerPublicKey(key, pass string) (signer ssh.Signer, err error) {
 	}
 
 	if pass != "" {
-		signer, err = ssh.ParsePrivateKeyWithPassphrase(keyData, []byte(pass))
+		signer, err = sshkeys.ParseEncryptedPrivateKey(keyData, []byte(pass))
 	} else {
 		rgx := regexp.MustCompile(`cannot decode`)
 		signer, err = ssh.ParsePrivateKey(keyData)
@@ -134,7 +135,7 @@ func createSshSignerPublicKey(key, pass string) (signer ssh.Signer, err error) {
 				for i := 0; i < rep; i++ {
 					pass, _ = common.GetPassPhase(msg)
 					pass = strings.TrimRight(pass, "\n")
-					sshSigner, err := ssh.ParsePrivateKeyWithPassphrase(keyData, []byte(pass))
+					sshSigner, err := sshkeys.ParseEncryptedPrivateKey(keyData, []byte(pass))
 					signer = sshSigner
 					if err == nil {
 						break


### PR DESCRIPTION
Fixes problems with encrypted ssh private keys (ed25519) by using 3rd party package (github.com/ScaleFT/sshkeys) and fixes issue when using "ProxyCommand none" in ssh/config. Perhaps using regex is better.


