### PR TITLE
use config file ~/.config/lssh/lssh.conf if exists, allow -f for lssh config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ option(lssh)
 
 	OPTIONS:
 	    --host servername, -H servername            connect servername.
-	    --file filepath, -F filepath                config filepath. (default: "/Users/blacknon/.lssh.conf")
+	    --file filepath, -F filepath, -f filepath   config filepath. (default: "/Users/blacknon/.lssh.conf")
 	    -L [bind_address:]port:remote_address:port  Local port forward mode.Specify a [bind_address:]port:remote_address:port.
 	    -R [bind_address:]port:remote_address:port  Remote port forward mode.Specify a [bind_address:]port:remote_address:port.
 	    -D port                                     Dynamic port forward mode(Socks5). Specify a port.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ brew install(Mac OS X)
 
 ## Config
 
-Please edit "~/.lssh.conf".\
-For details see [wiki](https://github.com/blacknon/lssh/wiki/Config).
+Default configuration file is either "~/.lssh.conf" or "~/.config/lssh/lssh.conf",
+the later being used if both exists.
+
+For details about configuration file content see [wiki](https://github.com/blacknon/lssh/wiki/Config).
 
 ## Usage
 

--- a/cmd/lscp/args.go
+++ b/cmd/lscp/args.go
@@ -23,6 +23,9 @@ func Lscp() (app *cli.App) {
 	// Default config file path
 	usr, _ := user.Current()
 	defConf := usr.HomeDir + "/.lssh.conf"
+	if _, err := os.Stat(usr.HomeDir + "/.config/lssh/lssh.conf"); err == nil {
+		defConf = usr.HomeDir + "/.config/lssh/lssh.conf"
+	}
 
 	// Set help templete
 	cli.AppHelpTemplate = `NAME:

--- a/cmd/lsftp/args.go
+++ b/cmd/lsftp/args.go
@@ -20,6 +20,9 @@ func Lsftp() (app *cli.App) {
 	// Default config file path
 	usr, _ := user.Current()
 	defConf := usr.HomeDir + "/.lssh.conf"
+	if _, err := os.Stat(usr.HomeDir + "/.config/lssh/lssh.conf"); err == nil {
+		defConf = usr.HomeDir + "/.config/lssh/lssh.conf"
+	}
 
 	// Set help templete
 	cli.AppHelpTemplate = `NAME:

--- a/cmd/lssh/args.go
+++ b/cmd/lssh/args.go
@@ -82,7 +82,7 @@ USAGE:
 	app.Flags = []cli.Flag{
 		// common option
 		cli.StringSliceFlag{Name: "host,H", Usage: "connect `servername`."},
-		cli.StringFlag{Name: "file,F", Value: defConf, Usage: "config `filepath`."},
+		cli.StringFlag{Name: "file,F,f", Value: defConf, Usage: "config `filepath`."},
 
 		// port forward option
 		cli.StringFlag{Name: "L", Usage: "Local port forward mode.Specify a `[bind_address:]port:remote_address:port`."},

--- a/cmd/lssh/args.go
+++ b/cmd/lssh/args.go
@@ -22,6 +22,9 @@ func Lssh() (app *cli.App) {
 	// Default config file path
 	usr, _ := user.Current()
 	defConf := usr.HomeDir + "/.lssh.conf"
+	if _, err := os.Stat(usr.HomeDir + "/.config/lssh/lssh.conf"); err == nil {
+		defConf = usr.HomeDir + "/.config/lssh/lssh.conf"
+	}
 
 	// Set help templete
 	cli.AppHelpTemplate = `NAME:


### PR DESCRIPTION
Hopping both commits are considered useful to be merged. The first one is about the default path to configuration file, and the second is to have more coherence on command line options across lssh, lscp and lsftp, `-f` being also easier to type by avoiding pressing SHIFT for uppercase.

    commit fcbe196: use ~/.config/lssh/lssh.conf as default config if exists
    
    - many distros adhere XDG Base Directory Specification
    - see: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
    - if this file does not exist, then ~/.lssh.conf is considered default config


    commit ef189bc: allow -f to be used for lssh to specify config file path
    
    - be more coherent with lscp and lsftp
    - -F kept for backward compatibility